### PR TITLE
Fix logging package

### DIFF
--- a/pkg/log/filesystem/filesystem.go
+++ b/pkg/log/filesystem/filesystem.go
@@ -18,9 +18,8 @@ type FilesystemHook struct {
 func New(path string) (*FilesystemHook, error) {
 	writer, err := rotatelogs.New(
 		path+".%Y%m%d%H%M",
-		rotatelogs.WithLinkName(path),
-		rotatelogs.WithMaxAge(time.Duration(86400)*time.Second),
-		rotatelogs.WithRotationTime(time.Duration(604800)*time.Second),
+		rotatelogs.WithMaxAge(24 * time.Hour),
+		rotatelogs.WithRotationTime(time.Hour),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Use more verbose logrotate settings (hours instead of seconds).
In advance remove usage of symlinks which lead to issues within
E2E tests.

Signed-off-by: Tobias Kohlbau <t.kohlbau@myopenfactory.com>