### PR TITLE
Fix update

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
@@ -24,6 +25,10 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			fmt.Println("Error occurred while detecting version:", err)
 			os.Exit(1)
+		}
+		
+		if strings.HasPrefix(version, "v") {
+			version = version[1:]
 		}
 
 		v := semver.MustParse(version)


### PR DESCRIPTION
During update the current version is checked against latest release.
Versions are named `vX.X.X`, the leading v is not supported by
github.com/blang/semver. Therefore it must be stripped before parsing
the semver version.

Signed-off-by: Tobias Kohlbau <t.kohlbau@myopenfactory.com>