### PR TITLE
configure HTTPS_PROXY in advance to HTTP_PROXY

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -172,6 +172,7 @@ func WithCertPool(pool *x509.CertPool) Option {
 func WithProxy(proxy string) Option {
 	return func(c *Client) {
 		os.Setenv("HTTP_PROXY", proxy)
+		os.Setenv("HTTPS_PROXY", proxy)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,9 @@ func ParseClientOptions() ([]client.Option, error) {
 	if proxy := os.Getenv("HTTP_PROXY"); proxy != "" {
 		opts = append(opts, client.WithProxy(proxy))
 	}
+	if proxy := os.Getenv("HTTPS_PROXY"); proxy != "" {
+		opts = append(opts, client.WithProxy(proxy))
+	}
 
 	crt, err := tls.LoadX509KeyPair(clientcert, clientcert)
 	if err != nil {


### PR DESCRIPTION
Go 1.16 no longer uses HTTP_PROXY as fallback for https urls.
Se https://golang.org/doc/go1.16#net/http for more information.

Fixes #91